### PR TITLE
fix the readme's section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@
 
 ### Catalog:
 - #### Manual
-    - ##### Type.
-    - ##### Base type.
-    - ##### Static member.
-    - ##### Member function.
-    - ##### Function.
-    - ##### Static funciton.
-    - ##### If statement.
-    - ##### Loop.
-    - ##### File include.
-    - ##### Manual header info construction.
-    - ##### Asm file including.
-    - ##### VTC.
-    - ##### Array.
-    - ##### Preprosessor.
-    - ##### Arguments.
-    - ##### Notices!
+    - [Type](#type).
+    - [Base type](#base-type).
+    - [Static member](#static-member).
+    - [Member function](#member-function).
+    - [Function](#function).
+    - [Static funciton](#static-function).
+    - [If statement](#if-statement).
+    - [Loop](#loop).
+    - [File include](#file-include).
+    - [Manual header info construction](#manual-header-info-construction).
+    - [Asm file including](#asm-file-including).
+    - [VTC](#vtc).
+    - [Array](#array).
+    - [Preprosessor](#preprosessor).
+    - [Arguments](#arguments).
+    - [Notices!](#notices)
 
 ## Manual
 


### PR DESCRIPTION
This Pull Request fixes the readme's links to itself.
It swaps out `- #####` for `-` and links the headers to their proper section.